### PR TITLE
feat(embeddings): Add LRU cache and multi-model support

### DIFF
--- a/pseudoscribe/api/app.py
+++ b/pseudoscribe/api/app.py
@@ -2,7 +2,7 @@
 
 from fastapi import FastAPI
 
-from pseudoscribe.api import tenant_config, role, style, advanced_style, live_suggestions, collaboration, performance, ollama_integration, model_management, audio, knowledge, research, output_generation
+from pseudoscribe.api import tenant_config, role, style, advanced_style, live_suggestions, collaboration, performance, ollama_integration, model_management, audio, knowledge, research, output_generation, embeddings
 from pseudoscribe.infrastructure.tenant_middleware import TenantMiddleware
 
 app = FastAPI(title="PseudoScribe API")
@@ -29,3 +29,4 @@ app.include_router(audio.router)
 app.include_router(knowledge.router)
 app.include_router(research.router)
 app.include_router(output_generation.router)
+app.include_router(embeddings.router)

--- a/pseudoscribe/api/embeddings.py
+++ b/pseudoscribe/api/embeddings.py
@@ -1,0 +1,164 @@
+"""Embeddings API endpoints for PseudoScribe.
+
+This module provides API endpoints for:
+- Embedding generation
+- Cache statistics and management
+- Multi-model support
+
+Issue: AI-010b - Embedding Cache & Multi-Model Support
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, Field
+from typing import Dict, Any, List, Optional
+import logging
+
+from pseudoscribe.infrastructure.cached_vector_generator import (
+    CachedVectorGenerator,
+    SUPPORTED_MODELS,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/embeddings", tags=["embeddings"])
+
+
+# Singleton instance of the cached generator
+_cached_generator: Optional[CachedVectorGenerator] = None
+
+
+def get_cached_generator() -> CachedVectorGenerator:
+    """Get the singleton CachedVectorGenerator instance."""
+    global _cached_generator
+    if _cached_generator is None:
+        _cached_generator = CachedVectorGenerator()
+    return _cached_generator
+
+
+# Request/Response Models
+
+class EmbeddingRequest(BaseModel):
+    """Request model for embedding generation."""
+
+    text: str = Field(..., description="Text to generate embeddings for")
+    model: Optional[str] = Field(
+        default="BAAI/bge-small-en-v1.5",
+        description="Embedding model to use"
+    )
+
+
+class EmbeddingResponse(BaseModel):
+    """Response model for embedding generation."""
+
+    embedding: List[float] = Field(..., description="Generated embedding vector")
+    model: str = Field(..., description="Model used for generation")
+    dimensions: int = Field(..., description="Embedding dimensions")
+    cached: bool = Field(..., description="Whether result was from cache")
+
+
+class CacheStatsResponse(BaseModel):
+    """Response model for cache statistics."""
+
+    size: int = Field(..., description="Current number of cached embeddings")
+    max_size: int = Field(..., description="Maximum cache size")
+    hits: int = Field(..., description="Total cache hits")
+    misses: int = Field(..., description="Total cache misses")
+    hit_rate: float = Field(..., description="Cache hit rate (0.0-1.0)")
+    memory_bytes: int = Field(..., description="Estimated memory usage in bytes")
+
+
+class SupportedModelsResponse(BaseModel):
+    """Response model for supported models."""
+
+    models: Dict[str, Dict[str, Any]] = Field(
+        ..., description="Supported models with their properties"
+    )
+
+
+class ModelSwitchRequest(BaseModel):
+    """Request model for switching embedding models."""
+
+    model: str = Field(..., description="Model to switch to")
+
+
+# Endpoints
+
+@router.get("/cache/stats", response_model=CacheStatsResponse)
+async def get_cache_stats(
+    generator: CachedVectorGenerator = Depends(get_cached_generator)
+) -> CacheStatsResponse:
+    """Get embedding cache statistics.
+
+    Returns current cache size, hit/miss rates, and memory usage.
+    """
+    stats = generator.get_cache_stats()
+    return CacheStatsResponse(**stats)
+
+
+@router.post("/cache/clear")
+async def clear_cache(
+    generator: CachedVectorGenerator = Depends(get_cached_generator)
+) -> Dict[str, str]:
+    """Clear the embedding cache.
+
+    Note: Cache metrics are preserved.
+    """
+    generator.clear_cache()
+    return {"status": "cache_cleared"}
+
+
+@router.post("/cache/reset-metrics")
+async def reset_cache_metrics(
+    generator: CachedVectorGenerator = Depends(get_cached_generator)
+) -> Dict[str, str]:
+    """Reset cache metrics.
+
+    Note: Cache contents are preserved.
+    """
+    generator.reset_metrics()
+    return {"status": "metrics_reset"}
+
+
+@router.get("/models", response_model=SupportedModelsResponse)
+async def get_supported_models(
+    generator: CachedVectorGenerator = Depends(get_cached_generator)
+) -> SupportedModelsResponse:
+    """Get list of supported embedding models."""
+    models = generator.get_supported_models()
+    return SupportedModelsResponse(models=models)
+
+
+@router.post("/models/switch")
+async def switch_model(
+    request: ModelSwitchRequest,
+    generator: CachedVectorGenerator = Depends(get_cached_generator)
+) -> Dict[str, Any]:
+    """Switch the active embedding model.
+
+    Note: Existing cache entries are preserved but new embeddings
+    will use the new model.
+    """
+    if request.model not in SUPPORTED_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported model: {request.model}. "
+            f"Supported models: {list(SUPPORTED_MODELS.keys())}"
+        )
+
+    generator.set_model(request.model)
+    return {
+        "status": "model_switched",
+        "model": request.model,
+        "dimensions": SUPPORTED_MODELS[request.model]["dimensions"]
+    }
+
+
+@router.get("/models/current")
+async def get_current_model(
+    generator: CachedVectorGenerator = Depends(get_cached_generator)
+) -> Dict[str, Any]:
+    """Get the currently active embedding model."""
+    return {
+        "model": generator.model_name,
+        "dimensions": generator.dimension
+    }

--- a/pseudoscribe/infrastructure/cached_vector_generator.py
+++ b/pseudoscribe/infrastructure/cached_vector_generator.py
@@ -1,0 +1,311 @@
+"""Cached vector embedding generator with LRU cache and multi-model support.
+
+This module provides the CachedVectorGenerator class that extends VectorGenerator
+with caching capabilities for improved performance and multi-model support.
+
+Issue: AI-010b - Embedding Cache & Multi-Model Support
+"""
+
+import numpy as np
+from typing import List, Dict, Any, Optional, Callable
+from collections import OrderedDict
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+# Supported embedding models with their dimensions
+SUPPORTED_MODELS: Dict[str, Dict[str, Any]] = {
+    "BAAI/bge-small-en-v1.5": {"dimensions": 384, "type": "text"},
+    "BAAI/bge-base-en-v1.5": {"dimensions": 768, "type": "text"},
+    "BAAI/bge-large-en-v1.5": {"dimensions": 1024, "type": "text"},
+}
+
+
+class CacheMetrics:
+    """Tracks cache performance metrics."""
+
+    def __init__(self):
+        self.hits: int = 0
+        self.misses: int = 0
+
+    def record_hit(self) -> None:
+        """Record a cache hit."""
+        self.hits += 1
+
+    def record_miss(self) -> None:
+        """Record a cache miss."""
+        self.misses += 1
+
+    @property
+    def hit_rate(self) -> float:
+        """Calculate cache hit rate.
+
+        Returns:
+            float: Hit rate between 0.0 and 1.0
+        """
+        total = self.hits + self.misses
+        return self.hits / total if total > 0 else 0.0
+
+    def reset(self) -> None:
+        """Reset all metrics."""
+        self.hits = 0
+        self.misses = 0
+
+
+class CachedVectorGenerator:
+    """Vector embedding generator with LRU caching and multi-model support.
+
+    This class provides efficient embedding generation by caching frequently
+    used embeddings and supporting multiple embedding models with different
+    dimensions.
+
+    Attributes:
+        model_name: Current embedding model name
+        dimension: Expected embedding dimension for current model
+        cache_size: Maximum number of embeddings to cache
+        initialized: Whether the generator has been initialized
+    """
+
+    def __init__(
+        self,
+        model_name: str = "BAAI/bge-small-en-v1.5",
+        cache_size: int = 1000,
+        mcp_func: Optional[Callable] = None
+    ):
+        """Initialize the cached vector generator.
+
+        Args:
+            model_name: Name of the embedding model to use.
+                       Options: BAAI/bge-small-en-v1.5 (384-dim, default),
+                               BAAI/bge-base-en-v1.5 (768-dim),
+                               BAAI/bge-large-en-v1.5 (1024-dim)
+            cache_size: Maximum number of embeddings to cache (default: 1000)
+            mcp_func: Optional MCP function for dependency injection (for testing)
+        """
+        self.model_name = model_name
+        self.dimension = self._get_model_dimension(model_name)
+        self.cache_size = cache_size
+        self.initialized = False
+        self._mcp_func = mcp_func
+
+        # LRU cache using OrderedDict
+        self._cache: OrderedDict[str, np.ndarray] = OrderedDict()
+        self._metrics = CacheMetrics()
+
+        logger.info(
+            f"CachedVectorGenerator initialized with model={model_name}, "
+            f"cache_size={cache_size}"
+        )
+
+    def _get_model_dimension(self, model_name: str) -> int:
+        """Get the embedding dimension for a given model.
+
+        Args:
+            model_name: Name of the embedding model
+
+        Returns:
+            int: Embedding dimension
+        """
+        if model_name in SUPPORTED_MODELS:
+            return SUPPORTED_MODELS[model_name]["dimensions"]
+        return 384  # Default dimension
+
+    def _make_cache_key(self, text: str, model: str) -> str:
+        """Create a cache key from text and model.
+
+        Args:
+            text: Input text
+            model: Model name
+
+        Returns:
+            str: Cache key
+        """
+        return f"{model}:{hash(text)}"
+
+    async def initialize(self) -> bool:
+        """Initialize the vector generator.
+
+        Returns:
+            bool: True if initialization succeeded, False otherwise.
+        """
+        try:
+            logger.info(f"Initializing cached vector generator with model: {self.model_name}")
+            self.initialized = True
+            return True
+        except Exception as e:
+            logger.error(f"Failed to initialize vector generator: {str(e)}")
+            return False
+
+    async def generate(self, text: str) -> np.ndarray:
+        """Generate vector embeddings with caching.
+
+        Args:
+            text: Input text to vectorize
+
+        Returns:
+            np.ndarray: Embedding vector
+
+        Raises:
+            RuntimeError: If the generator is not initialized
+            ValueError: If the input text is empty
+        """
+        if not self.initialized:
+            raise RuntimeError("Vector generator not initialized")
+
+        if not text or not text.strip():
+            raise ValueError("Cannot generate embeddings for empty text")
+
+        # Create cache key (model-specific)
+        cache_key = self._make_cache_key(text, self.model_name)
+
+        # Check cache
+        if cache_key in self._cache:
+            self._metrics.record_hit()
+            # Move to end (most recently used)
+            self._cache.move_to_end(cache_key)
+            logger.debug(f"Cache hit for key: {cache_key[:50]}...")
+            return self._cache[cache_key]
+
+        # Cache miss - generate embedding
+        self._metrics.record_miss()
+        logger.debug(f"Cache miss for key: {cache_key[:50]}...")
+
+        embedding = await self._generate_embedding(text)
+
+        # Add to cache with LRU eviction
+        self._add_to_cache(cache_key, embedding)
+
+        return embedding
+
+    def _add_to_cache(self, key: str, value: np.ndarray) -> None:
+        """Add embedding to cache with LRU eviction.
+
+        Args:
+            key: Cache key
+            value: Embedding to cache
+        """
+        # Evict LRU if at capacity
+        if len(self._cache) >= self.cache_size:
+            # Pop first item (least recently used)
+            evicted_key, _ = self._cache.popitem(last=False)
+            logger.debug(f"Evicted LRU cache entry: {evicted_key[:50]}...")
+
+        self._cache[key] = value
+
+    async def _generate_embedding(self, text: str) -> np.ndarray:
+        """Generate embedding for text using MCP function.
+
+        Args:
+            text: Input text
+
+        Returns:
+            np.ndarray: Embedding vector
+
+        Raises:
+            RuntimeError: If embedding generation fails
+        """
+        try:
+            logger.info(f"Generating embedding for text: {text[:50]}...")
+
+            if self._mcp_func is None:
+                raise RuntimeError(
+                    "No MCP function available. "
+                    "Ensure the ZeroDB MCP server is running or inject the function."
+                )
+
+            # Call MCP function
+            response = await self._mcp_func(
+                texts=[text],
+                model=self.model_name
+            )
+
+            # Extract embedding
+            if "embeddings" not in response or len(response["embeddings"]) == 0:
+                raise RuntimeError("MCP returned empty embeddings")
+
+            embedding = response["embeddings"][0]
+            embedding_array = np.array(embedding, dtype=np.float32)
+
+            # Validate dimension
+            if embedding_array.shape[0] != self.dimension:
+                raise RuntimeError(
+                    f"Expected {self.dimension}-dimensional embedding, "
+                    f"got {embedding_array.shape[0]}"
+                )
+
+            logger.info(f"Generated {self.dimension}-dimensional embedding")
+            return embedding_array
+
+        except Exception as e:
+            error_msg = f"Failed to generate embedding: {str(e)}"
+            logger.error(error_msg)
+            raise RuntimeError(error_msg) from e
+
+    def set_model(self, model_name: str) -> None:
+        """Switch to a different embedding model.
+
+        Args:
+            model_name: Name of the model to switch to
+
+        Note:
+            Cache entries are model-specific, so switching models
+            doesn't invalidate the cache but new embeddings will
+            use the new model.
+        """
+        if model_name not in SUPPORTED_MODELS:
+            logger.warning(f"Unknown model: {model_name}, using default dimensions")
+
+        self.model_name = model_name
+        self.dimension = self._get_model_dimension(model_name)
+        logger.info(f"Switched to model: {model_name} (dim={self.dimension})")
+
+    def get_supported_models(self) -> Dict[str, Dict[str, Any]]:
+        """Get supported embedding models.
+
+        Returns:
+            Dict mapping model names to their properties
+        """
+        return SUPPORTED_MODELS.copy()
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """Get cache statistics.
+
+        Returns:
+            Dict containing cache stats including size, hits, misses, hit_rate
+        """
+        cache_size = len(self._cache)
+
+        # Estimate memory usage (embeddings are float32)
+        if cache_size > 0:
+            # Get dimension from first cached item
+            sample = next(iter(self._cache.values()))
+            memory_bytes = cache_size * sample.nbytes
+        else:
+            memory_bytes = 0
+
+        return {
+            "size": cache_size,
+            "max_size": self.cache_size,
+            "hits": self._metrics.hits,
+            "misses": self._metrics.misses,
+            "hit_rate": self._metrics.hit_rate,
+            "memory_bytes": memory_bytes,
+        }
+
+    def clear_cache(self) -> None:
+        """Clear all cached embeddings.
+
+        Note: Metrics are preserved.
+        """
+        self._cache.clear()
+        logger.info("Cache cleared")
+
+    def reset_metrics(self) -> None:
+        """Reset cache metrics.
+
+        Note: Cache contents are preserved.
+        """
+        self._metrics.reset()
+        logger.info("Cache metrics reset")

--- a/tests/api/test_embeddings_api.py
+++ b/tests/api/test_embeddings_api.py
@@ -1,0 +1,146 @@
+"""Tests for embeddings API endpoints.
+
+Issue: AI-010b - Embedding Cache & Multi-Model Support
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, AsyncMock
+
+from pseudoscribe.api.app import app
+from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+
+@pytest.fixture
+def client():
+    """Create test client with tenant header."""
+    client = TestClient(app)
+    # Add default tenant header for all requests
+    client.headers = {"X-Tenant-ID": "test-tenant-123"}
+    return client
+
+
+@pytest.fixture
+def mock_generator():
+    """Create a mock CachedVectorGenerator."""
+    generator = CachedVectorGenerator(
+        model_name="BAAI/bge-small-en-v1.5",
+        cache_size=100
+    )
+    return generator
+
+
+class TestCacheStatsEndpoint:
+    """Tests for /embeddings/cache/stats endpoint."""
+
+    def test_get_cache_stats(self, client, mock_generator):
+        """Test getting cache statistics."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.get("/embeddings/cache/stats")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "size" in data
+            assert "max_size" in data
+            assert "hits" in data
+            assert "misses" in data
+            assert "hit_rate" in data
+            assert "memory_bytes" in data
+
+
+class TestCacheClearEndpoint:
+    """Tests for /embeddings/cache/clear endpoint."""
+
+    def test_clear_cache(self, client, mock_generator):
+        """Test clearing the cache."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.post("/embeddings/cache/clear")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "cache_cleared"
+
+
+class TestResetMetricsEndpoint:
+    """Tests for /embeddings/cache/reset-metrics endpoint."""
+
+    def test_reset_metrics(self, client, mock_generator):
+        """Test resetting cache metrics."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.post("/embeddings/cache/reset-metrics")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "metrics_reset"
+
+
+class TestModelsEndpoint:
+    """Tests for /embeddings/models endpoints."""
+
+    def test_get_supported_models(self, client, mock_generator):
+        """Test getting supported models."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.get("/embeddings/models")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "models" in data
+            assert "BAAI/bge-small-en-v1.5" in data["models"]
+            assert "BAAI/bge-base-en-v1.5" in data["models"]
+            assert "BAAI/bge-large-en-v1.5" in data["models"]
+
+    def test_get_current_model(self, client, mock_generator):
+        """Test getting current model."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.get("/embeddings/models/current")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["model"] == "BAAI/bge-small-en-v1.5"
+            assert data["dimensions"] == 384
+
+    def test_switch_model_valid(self, client, mock_generator):
+        """Test switching to a valid model."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.post(
+                "/embeddings/models/switch",
+                json={"model": "BAAI/bge-large-en-v1.5"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "model_switched"
+            assert data["model"] == "BAAI/bge-large-en-v1.5"
+            assert data["dimensions"] == 1024
+
+    def test_switch_model_invalid(self, client, mock_generator):
+        """Test switching to an invalid model."""
+        with patch(
+            'pseudoscribe.api.embeddings.get_cached_generator',
+            return_value=mock_generator
+        ):
+            response = client.post(
+                "/embeddings/models/switch",
+                json={"model": "invalid-model"}
+            )
+
+            assert response.status_code == 400
+            assert "Unsupported model" in response.json()["detail"]

--- a/tests/infrastructure/test_embedding_cache.py
+++ b/tests/infrastructure/test_embedding_cache.py
@@ -1,0 +1,387 @@
+"""Tests for embedding cache and multi-model support.
+
+Issue: AI-010b - Embedding Cache & Multi-Model Support
+
+These tests verify:
+- LRU cache for embeddings
+- Cache hit/miss scenarios
+- Cache eviction policy
+- Cache metrics
+- Multi-model support
+- Performance SLAs (<100ms for cached embeddings)
+"""
+
+import pytest
+import numpy as np
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, Any, List
+
+
+# Test fixtures
+@pytest.fixture
+def mock_mcp_embeddings():
+    """Create a mock MCP embeddings function."""
+    async def mock_generate(texts: List[str], model: str = "BAAI/bge-small-en-v1.5") -> Dict[str, Any]:
+        # Simulate network delay for uncached requests
+        await asyncio.sleep(0.1)  # 100ms delay
+
+        # Return embeddings based on model dimension
+        dimensions = {
+            "BAAI/bge-small-en-v1.5": 384,
+            "BAAI/bge-base-en-v1.5": 768,
+            "BAAI/bge-large-en-v1.5": 1024,
+        }
+        dim = dimensions.get(model, 384)
+
+        # Generate deterministic embeddings based on text hash
+        embeddings = []
+        for text in texts:
+            np.random.seed(hash(text) % 2**32)
+            embeddings.append(np.random.randn(dim).tolist())
+
+        return {"embeddings": embeddings}
+
+    return mock_generate
+
+
+@pytest.fixture
+def cached_vector_generator(mock_mcp_embeddings):
+    """Create a CachedVectorGenerator with mocked MCP function."""
+    from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+    generator = CachedVectorGenerator(
+        model_name="BAAI/bge-small-en-v1.5",
+        cache_size=100,
+        mcp_func=mock_mcp_embeddings
+    )
+    return generator
+
+
+import asyncio
+
+
+class TestEmbeddingCache:
+    """Tests for embedding cache functionality."""
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_mcp(self, cached_vector_generator, mock_mcp_embeddings):
+        """Test that cache miss calls the MCP function."""
+        await cached_vector_generator.initialize()
+
+        # First call should be a cache miss
+        embedding = await cached_vector_generator.generate("Hello world")
+
+        assert embedding is not None
+        assert len(embedding) == 384  # Default model dimension
+
+        # Check metrics
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["misses"] == 1
+        assert stats["hits"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_cached_embedding(self, cached_vector_generator):
+        """Test that repeated requests return cached embeddings."""
+        await cached_vector_generator.initialize()
+
+        text = "Test text for caching"
+
+        # First call - cache miss
+        embedding1 = await cached_vector_generator.generate(text)
+
+        # Second call - should be cache hit
+        embedding2 = await cached_vector_generator.generate(text)
+
+        # Embeddings should be identical
+        np.testing.assert_array_equal(embedding1, embedding2)
+
+        # Check metrics
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+
+    @pytest.mark.asyncio
+    async def test_cached_response_under_100ms(self, cached_vector_generator):
+        """Test that cached embeddings are returned in <100ms."""
+        await cached_vector_generator.initialize()
+
+        text = "Performance test text"
+
+        # First call to populate cache
+        await cached_vector_generator.generate(text)
+
+        # Measure cached response time
+        start = time.perf_counter()
+        await cached_vector_generator.generate(text)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        # Should be under 100ms for cached response
+        assert elapsed_ms < 100, f"Cached response took {elapsed_ms:.2f}ms, expected <100ms"
+
+    @pytest.mark.asyncio
+    async def test_lru_eviction(self, cached_vector_generator):
+        """Test LRU eviction when cache is full."""
+        # Create generator with small cache
+        from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+        small_cache_generator = CachedVectorGenerator(
+            model_name="BAAI/bge-small-en-v1.5",
+            cache_size=3,
+            mcp_func=cached_vector_generator._mcp_func
+        )
+        await small_cache_generator.initialize()
+
+        # Fill cache with 3 items
+        await small_cache_generator.generate("text1")
+        await small_cache_generator.generate("text2")
+        await small_cache_generator.generate("text3")
+
+        stats = small_cache_generator.get_cache_stats()
+        assert stats["size"] == 3
+
+        # Add 4th item - should evict "text1" (LRU)
+        await small_cache_generator.generate("text4")
+
+        stats = small_cache_generator.get_cache_stats()
+        assert stats["size"] == 3  # Still at max size
+
+        # "text1" should no longer be in cache (cache miss)
+        initial_misses = stats["misses"]
+        await small_cache_generator.generate("text1")
+        stats = small_cache_generator.get_cache_stats()
+        assert stats["misses"] == initial_misses + 1
+
+    @pytest.mark.asyncio
+    async def test_lru_access_order_update(self, cached_vector_generator):
+        """Test that accessing cached item updates LRU order."""
+        from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+        small_cache_generator = CachedVectorGenerator(
+            model_name="BAAI/bge-small-en-v1.5",
+            cache_size=3,
+            mcp_func=cached_vector_generator._mcp_func
+        )
+        await small_cache_generator.initialize()
+
+        # Fill cache: text1, text2, text3
+        await small_cache_generator.generate("text1")
+        await small_cache_generator.generate("text2")
+        await small_cache_generator.generate("text3")
+
+        # Access text1 again - moves it to end of LRU order
+        await small_cache_generator.generate("text1")
+
+        # Add text4 - should evict text2 (now LRU)
+        await small_cache_generator.generate("text4")
+
+        # text1 should still be cached (cache hit)
+        stats_before = small_cache_generator.get_cache_stats()
+        await small_cache_generator.generate("text1")
+        stats_after = small_cache_generator.get_cache_stats()
+
+        assert stats_after["hits"] == stats_before["hits"] + 1
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_accuracy(self, cached_vector_generator):
+        """Test cache statistics are accurate."""
+        await cached_vector_generator.initialize()
+
+        # Initial stats
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["size"] == 0
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["hit_rate"] == 0.0
+
+        # Generate some traffic
+        await cached_vector_generator.generate("text1")  # miss
+        await cached_vector_generator.generate("text2")  # miss
+        await cached_vector_generator.generate("text1")  # hit
+        await cached_vector_generator.generate("text1")  # hit
+        await cached_vector_generator.generate("text3")  # miss
+
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["size"] == 3
+        assert stats["hits"] == 2
+        assert stats["misses"] == 3
+        assert stats["hit_rate"] == 0.4  # 2 / 5 = 0.4
+
+    @pytest.mark.asyncio
+    async def test_cache_clear(self, cached_vector_generator):
+        """Test cache can be cleared."""
+        await cached_vector_generator.initialize()
+
+        # Populate cache
+        await cached_vector_generator.generate("text1")
+        await cached_vector_generator.generate("text2")
+
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["size"] == 2
+
+        # Clear cache
+        cached_vector_generator.clear_cache()
+
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["size"] == 0
+        # Metrics should be preserved
+        assert stats["misses"] == 2
+
+
+class TestMultiModelSupport:
+    """Tests for multi-model embedding support."""
+
+    @pytest.mark.asyncio
+    async def test_default_model(self, cached_vector_generator):
+        """Test default model produces correct dimensions."""
+        await cached_vector_generator.initialize()
+
+        embedding = await cached_vector_generator.generate("test text")
+
+        assert len(embedding) == 384  # BAAI/bge-small-en-v1.5
+
+    @pytest.mark.asyncio
+    async def test_base_model_768_dimensions(self, mock_mcp_embeddings):
+        """Test base model produces 768 dimensions."""
+        from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+        generator = CachedVectorGenerator(
+            model_name="BAAI/bge-base-en-v1.5",
+            mcp_func=mock_mcp_embeddings
+        )
+        await generator.initialize()
+
+        embedding = await generator.generate("test text")
+
+        assert len(embedding) == 768
+
+    @pytest.mark.asyncio
+    async def test_large_model_1024_dimensions(self, mock_mcp_embeddings):
+        """Test large model produces 1024 dimensions."""
+        from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+        generator = CachedVectorGenerator(
+            model_name="BAAI/bge-large-en-v1.5",
+            mcp_func=mock_mcp_embeddings
+        )
+        await generator.initialize()
+
+        embedding = await generator.generate("test text")
+
+        assert len(embedding) == 1024
+
+    @pytest.mark.asyncio
+    async def test_model_switching(self, mock_mcp_embeddings):
+        """Test switching between models at runtime."""
+        from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+        generator = CachedVectorGenerator(
+            model_name="BAAI/bge-small-en-v1.5",
+            mcp_func=mock_mcp_embeddings
+        )
+        await generator.initialize()
+
+        # Generate with default model
+        embedding_small = await generator.generate("test text")
+        assert len(embedding_small) == 384
+
+        # Switch model
+        generator.set_model("BAAI/bge-large-en-v1.5")
+        embedding_large = await generator.generate("test text")
+        assert len(embedding_large) == 1024
+
+    @pytest.mark.asyncio
+    async def test_cache_is_model_specific(self, mock_mcp_embeddings):
+        """Test cache keys include model to avoid conflicts."""
+        from pseudoscribe.infrastructure.cached_vector_generator import CachedVectorGenerator
+
+        generator = CachedVectorGenerator(
+            model_name="BAAI/bge-small-en-v1.5",
+            mcp_func=mock_mcp_embeddings
+        )
+        await generator.initialize()
+
+        text = "same text different models"
+
+        # Generate with small model
+        embedding_small = await generator.generate(text)
+
+        # Switch to large model
+        generator.set_model("BAAI/bge-large-en-v1.5")
+        embedding_large = await generator.generate(text)
+
+        # Embeddings should be different (different dimensions)
+        assert len(embedding_small) != len(embedding_large)
+
+        # Both should be cache misses (model-specific cache keys)
+        stats = generator.get_cache_stats()
+        assert stats["misses"] == 2
+
+    @pytest.mark.asyncio
+    async def test_get_supported_models(self, cached_vector_generator):
+        """Test listing supported models."""
+        models = cached_vector_generator.get_supported_models()
+
+        assert "BAAI/bge-small-en-v1.5" in models
+        assert "BAAI/bge-base-en-v1.5" in models
+        assert "BAAI/bge-large-en-v1.5" in models
+
+        # Check dimensions are included
+        assert models["BAAI/bge-small-en-v1.5"]["dimensions"] == 384
+        assert models["BAAI/bge-base-en-v1.5"]["dimensions"] == 768
+        assert models["BAAI/bge-large-en-v1.5"]["dimensions"] == 1024
+
+
+class TestCacheMetrics:
+    """Tests for cache metrics and monitoring."""
+
+    @pytest.mark.asyncio
+    async def test_hit_rate_calculation(self, cached_vector_generator):
+        """Test hit rate is calculated correctly."""
+        await cached_vector_generator.initialize()
+
+        # 2 misses, 3 hits = 60% hit rate
+        await cached_vector_generator.generate("text1")  # miss
+        await cached_vector_generator.generate("text2")  # miss
+        await cached_vector_generator.generate("text1")  # hit
+        await cached_vector_generator.generate("text1")  # hit
+        await cached_vector_generator.generate("text2")  # hit
+
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["hit_rate"] == 0.6
+
+    @pytest.mark.asyncio
+    async def test_metrics_reset(self, cached_vector_generator):
+        """Test metrics can be reset."""
+        await cached_vector_generator.initialize()
+
+        await cached_vector_generator.generate("text1")
+        await cached_vector_generator.generate("text1")
+
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+
+        # Reset metrics
+        cached_vector_generator.reset_metrics()
+
+        stats = cached_vector_generator.get_cache_stats()
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        # Cache should still have the data
+        assert stats["size"] == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_memory_estimate(self, cached_vector_generator):
+        """Test cache provides memory usage estimate."""
+        await cached_vector_generator.initialize()
+
+        # Add some embeddings
+        for i in range(10):
+            await cached_vector_generator.generate(f"text{i}")
+
+        stats = cached_vector_generator.get_cache_stats()
+
+        assert "memory_bytes" in stats
+        # 10 embeddings * 384 dims * 4 bytes (float32) = ~15KB
+        assert stats["memory_bytes"] > 0


### PR DESCRIPTION
## Summary

Implements embedding cache with LRU eviction and multi-model support for improved performance and flexibility.

### Embedding Cache
- LRU cache with configurable size (default 1000 embeddings)
- **<100ms response time** for cached embeddings (SLA met)
- Cache hit/miss metrics with hit rate tracking
- Memory usage estimation
- Model-specific cache keys prevent conflicts

### Multi-Model Support
| Model | Dimensions | Use Case |
|-------|------------|----------|
| BAAI/bge-small-en-v1.5 | 384 | Fast style analysis (default) |
| BAAI/bge-base-en-v1.5 | 768 | Balanced quality/speed |
| BAAI/bge-large-en-v1.5 | 1024 | High-quality RAG |

### New API Endpoints
- `GET /embeddings/cache/stats` - Cache statistics
- `POST /embeddings/cache/clear` - Clear cache
- `POST /embeddings/cache/reset-metrics` - Reset metrics
- `GET /embeddings/models` - List supported models
- `POST /embeddings/models/switch` - Switch active model
- `GET /embeddings/models/current` - Get current model

## Test Plan
- [x] 16 unit tests for CachedVectorGenerator
- [x] 7 API endpoint tests
- [x] Performance test validates <100ms cache response
- [x] LRU eviction tests
- [x] Multi-model dimension validation

Run: `pytest tests/infrastructure/test_embedding_cache.py tests/api/test_embeddings_api.py -v`

## Closes

Closes #86