### PR TITLE
feat(strapi): Add StrapiConnector service extending BaseContentConnector

### DIFF
--- a/pseudoscribe/infrastructure/strapi_connector.py
+++ b/pseudoscribe/infrastructure/strapi_connector.py
@@ -1,0 +1,290 @@
+"""Strapi Connector Service.
+
+Issue: INT-003 - Strapi Connector Service
+
+This module provides the Strapi connector implementation:
+- Extends BaseContentConnector for unified interface
+- Uses StrapiMCPClient for MCP operations
+- Registers with ConnectorRegistry for discovery
+- Supports multi-tenant isolation
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pseudoscribe.infrastructure.content_connector import (
+    BaseContentConnector,
+    ContentItem,
+    ContentSchema,
+    ConnectorStatus,
+    ContentNotFoundError,
+    register_connector
+)
+from pseudoscribe.infrastructure.tenant_config_service import TenantConfigService
+from pseudoscribe.infrastructure.strapi_mcp_client import (
+    StrapiMCPClient,
+    StrapiContentNotFoundError,
+    StrapiMCPError
+)
+
+
+# Connector type constant
+STRAPI_CONNECTOR_TYPE = "strapi"
+
+
+class StrapiConnector(BaseContentConnector):
+    """Strapi CMS connector implementation.
+
+    Extends BaseContentConnector to provide a unified interface for
+    interacting with Strapi CMS via the StrapiMCPClient.
+    """
+
+    connector_type: str = STRAPI_CONNECTOR_TYPE
+
+    def __init__(
+        self,
+        tenant_id: str,
+        credential_id: str,
+        config_service: TenantConfigService
+    ):
+        """Initialize the Strapi connector.
+
+        Args:
+            tenant_id: The tenant this connector belongs to
+            credential_id: ID of stored credentials to use
+            config_service: Service for accessing tenant configuration
+        """
+        super().__init__(tenant_id, credential_id, config_service)
+        self._connected = False
+        self._client: Optional[StrapiMCPClient] = None
+        self._default_content_type = "article"
+
+    def set_default_content_type(self, content_type: str) -> None:
+        """Set the default content type for operations.
+
+        Args:
+            content_type: The default content type (e.g., "article", "blog")
+        """
+        self._default_content_type = content_type
+
+    def _get_client(self) -> StrapiMCPClient:
+        """Get the MCP client instance.
+
+        Returns:
+            The StrapiMCPClient singleton instance
+        """
+        if self._client is None:
+            self._client = StrapiMCPClient.get_instance()
+        return self._client
+
+    async def connect(self) -> bool:
+        """Establish connection to Strapi via MCP.
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        try:
+            client = self._get_client()
+
+            # Configure the tenant in the MCP client
+            client.configure_tenant(
+                tenant_id=self.tenant_id,
+                credential_id=self.credential_id,
+                config_service=self._config_service
+            )
+
+            # Verify connection with health check
+            status = await client.health_check(self.tenant_id)
+            self._connected = status.connected
+
+            return self._connected
+
+        except Exception:
+            self._connected = False
+            return False
+
+    async def disconnect(self) -> None:
+        """Close the connection to Strapi.
+
+        Note: MCP client is a singleton, so we just mark as disconnected.
+        """
+        self._connected = False
+
+    async def health_check(self) -> ConnectorStatus:
+        """Check the health of the Strapi connection.
+
+        Returns:
+            ConnectorStatus with connection details
+        """
+        if not self._connected:
+            return ConnectorStatus(
+                connected=False,
+                message="Not connected",
+                last_check=datetime.now()
+            )
+
+        try:
+            client = self._get_client()
+            return await client.health_check(self.tenant_id)
+        except Exception as e:
+            return ConnectorStatus(
+                connected=False,
+                message="Health check failed",
+                last_check=datetime.now(),
+                error=str(e)
+            )
+
+    async def fetch_content(
+        self,
+        content_id: str,
+        content_type: Optional[str] = None
+    ) -> ContentItem:
+        """Fetch content by ID from Strapi.
+
+        Args:
+            content_id: The document ID of the content to fetch
+            content_type: Optional content type (uses default if not specified)
+
+        Returns:
+            ContentItem with the content data
+
+        Raises:
+            ContentNotFoundError: If content doesn't exist
+        """
+        try:
+            client = self._get_client()
+            return await client.fetch_content(
+                tenant_id=self.tenant_id,
+                content_type=content_type or self._default_content_type,
+                document_id=content_id
+            )
+        except StrapiContentNotFoundError as e:
+            raise ContentNotFoundError(str(e)) from e
+
+    async def push_content(self, content: ContentItem) -> str:
+        """Push new content to Strapi.
+
+        Args:
+            content: The content to create
+
+        Returns:
+            The document ID of the created content
+        """
+        client = self._get_client()
+        return await client.push_content(
+            tenant_id=self.tenant_id,
+            content=content
+        )
+
+    async def update_content(
+        self,
+        content_id: str,
+        content: ContentItem
+    ) -> bool:
+        """Update existing content in Strapi.
+
+        Args:
+            content_id: The document ID of the content to update
+            content: The new content data
+
+        Returns:
+            True if updated successfully, False if not found
+        """
+        client = self._get_client()
+        return await client.update_content(
+            tenant_id=self.tenant_id,
+            document_id=content_id,
+            content=content
+        )
+
+    async def list_content(
+        self,
+        content_type: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0
+    ) -> List[ContentItem]:
+        """List content from Strapi.
+
+        Args:
+            content_type: Optional filter by content type
+            limit: Maximum number of items to return
+            offset: Number of items to skip
+
+        Returns:
+            List of ContentItems
+        """
+        client = self._get_client()
+        return await client.list_content(
+            tenant_id=self.tenant_id,
+            content_type=content_type or self._default_content_type,
+            limit=limit,
+            offset=offset
+        )
+
+    async def get_schema(self, content_type: str) -> ContentSchema:
+        """Get the schema for a content type from Strapi.
+
+        Args:
+            content_type: The content type to get schema for
+
+        Returns:
+            ContentSchema with field definitions
+        """
+        client = self._get_client()
+        return await client.get_schema(
+            tenant_id=self.tenant_id,
+            content_type=content_type
+        )
+
+    async def delete_content(self, content_id: str) -> bool:
+        """Delete content by ID from Strapi.
+
+        Args:
+            content_id: The document ID of the content to delete
+
+        Returns:
+            True if deleted, False if not found
+
+        Note: This requires the MCP client to support delete operations.
+        """
+        # Delete is optional - check if client supports it
+        client = self._get_client()
+        if hasattr(client, 'delete_content'):
+            return await client.delete_content(
+                tenant_id=self.tenant_id,
+                document_id=content_id
+            )
+        raise NotImplementedError("Delete not supported by this connector")
+
+    async def search_content(
+        self,
+        query: str,
+        content_type: Optional[str] = None,
+        limit: int = 100
+    ) -> List[ContentItem]:
+        """Search content in Strapi.
+
+        Args:
+            query: Search query string
+            content_type: Optional filter by content type
+            limit: Maximum number of items to return
+
+        Returns:
+            List of matching ContentItems
+
+        Note: Search functionality depends on Strapi configuration.
+        """
+        # Search is optional - check if client supports it
+        client = self._get_client()
+        if hasattr(client, 'search_content'):
+            return await client.search_content(
+                tenant_id=self.tenant_id,
+                query=query,
+                content_type=content_type,
+                limit=limit
+            )
+        raise NotImplementedError("Search not supported by this connector")
+
+
+# Register the connector with the global registry
+register_connector(STRAPI_CONNECTOR_TYPE, StrapiConnector)

--- a/tests/infrastructure/test_strapi_connector.py
+++ b/tests/infrastructure/test_strapi_connector.py
@@ -1,0 +1,733 @@
+"""Tests for Strapi Connector Service.
+
+Issue: INT-003 - Strapi Connector Service
+
+These tests verify:
+- StrapiConnector extends BaseContentConnector
+- Integration with StrapiMCPClient
+- Content CRUD operations
+- Connector registration
+- Multi-tenant support
+"""
+
+import pytest
+from datetime import datetime
+from typing import Dict, Any, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pseudoscribe.infrastructure.strapi_connector import (
+    StrapiConnector,
+    STRAPI_CONNECTOR_TYPE
+)
+from pseudoscribe.infrastructure.content_connector import (
+    BaseContentConnector,
+    ContentItem,
+    ContentSchema,
+    ContentField,
+    FieldType,
+    ConnectorStatus,
+    ConnectorRegistry,
+    ContentNotFoundError,
+    get_connector_registry,
+    register_connector
+)
+from pseudoscribe.infrastructure.tenant_config_service import (
+    TenantConfigService,
+    ConnectorCredentials,
+    CredentialType
+)
+from pseudoscribe.infrastructure.strapi_mcp_client import (
+    StrapiMCPClient,
+    StrapiContentNotFoundError
+)
+
+
+class TestStrapiConnectorInheritance:
+    """Tests for StrapiConnector class inheritance."""
+
+    def test_extends_base_content_connector(self):
+        """Test that StrapiConnector extends BaseContentConnector."""
+        # Assert
+        assert issubclass(StrapiConnector, BaseContentConnector)
+
+    def test_has_connector_type(self):
+        """Test that StrapiConnector has correct connector_type."""
+        # Assert
+        assert StrapiConnector.connector_type == "strapi"
+        assert STRAPI_CONNECTOR_TYPE == "strapi"
+
+
+class TestStrapiConnectorInitialization:
+    """Tests for connector initialization."""
+
+    @pytest.fixture
+    def config_service(self):
+        """Create a TenantConfigService instance."""
+        return TenantConfigService()
+
+    @pytest.fixture
+    def strapi_credentials(self, config_service):
+        """Create and store Strapi credentials."""
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_api_token"
+        ))
+        return cred_id
+
+    def test_create_connector(self, config_service, strapi_credentials):
+        """Test creating a StrapiConnector instance."""
+        # Act
+        connector = StrapiConnector(
+            tenant_id="tenant-123",
+            credential_id=strapi_credentials,
+            config_service=config_service
+        )
+
+        # Assert
+        assert connector.tenant_id == "tenant-123"
+        assert connector.credential_id == strapi_credentials
+
+    def test_connector_stores_credentials(self, config_service, strapi_credentials):
+        """Test that connector can access credentials."""
+        # Arrange
+        connector = StrapiConnector(
+            tenant_id="tenant-123",
+            credential_id=strapi_credentials,
+            config_service=config_service
+        )
+
+        # Act
+        creds = connector.get_credentials()
+
+        # Assert
+        assert creds is not None
+        assert creds.api_url == "https://strapi.example.com"
+
+
+class TestStrapiConnectorConnection:
+    """Tests for connection management."""
+
+    @pytest.fixture
+    def connector(self):
+        """Create a configured connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        return StrapiConnector("tenant-123", cred_id, config_service)
+
+    @pytest.mark.asyncio
+    async def test_connect_success(self, connector):
+        """Test successful connection."""
+        # Arrange
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.configure_tenant = MagicMock()
+            mock_client.health_check = AsyncMock(return_value=ConnectorStatus(
+                connected=True,
+                message="Connected",
+                last_check=datetime.now()
+            ))
+            mock_get.return_value = mock_client
+
+            # Act
+            result = await connector.connect()
+
+            # Assert
+            assert result is True
+            mock_client.configure_tenant.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_failure(self, connector):
+        """Test connection failure."""
+        # Arrange
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.configure_tenant = MagicMock()
+            mock_client.health_check = AsyncMock(return_value=ConnectorStatus(
+                connected=False,
+                message="Connection failed",
+                last_check=datetime.now(),
+                error="Timeout"
+            ))
+            mock_get.return_value = mock_client
+
+            # Act
+            result = await connector.connect()
+
+            # Assert
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self, connector):
+        """Test disconnection."""
+        # Arrange
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.configure_tenant = MagicMock()
+            mock_client.health_check = AsyncMock(return_value=ConnectorStatus(
+                connected=True,
+                message="Connected",
+                last_check=datetime.now()
+            ))
+            mock_get.return_value = mock_client
+
+            await connector.connect()
+
+            # Act
+            await connector.disconnect()
+
+            # Assert - should not raise
+            assert True
+
+    @pytest.mark.asyncio
+    async def test_health_check(self, connector):
+        """Test health check."""
+        # Arrange
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.configure_tenant = MagicMock()
+            mock_client.health_check = AsyncMock(return_value=ConnectorStatus(
+                connected=True,
+                message="Strapi connection healthy",
+                last_check=datetime.now(),
+                latency_ms=50.0
+            ))
+            mock_get.return_value = mock_client
+
+            await connector.connect()
+
+            # Act
+            status = await connector.health_check()
+
+            # Assert
+            assert status.connected is True
+            assert "healthy" in status.message.lower()
+
+
+class TestStrapiConnectorFetchContent:
+    """Tests for fetching content."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector with mocked MCP client."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_success(self, connected_connector):
+        """Test fetching content by ID."""
+        # Arrange
+        expected_item = ContentItem(
+            content_id="abc123",
+            content_type="article",
+            title="Test Article",
+            body="Article body content",
+            status="draft"
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.fetch_content = AsyncMock(return_value=expected_item)
+            mock_get.return_value = mock_client
+
+            # Act
+            result = await connected_connector.fetch_content("abc123")
+
+            # Assert
+            assert result.content_id == "abc123"
+            assert result.title == "Test Article"
+            assert result.body == "Article body content"
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_not_found(self, connected_connector):
+        """Test fetching nonexistent content raises error."""
+        # Arrange
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.fetch_content = AsyncMock(
+                side_effect=StrapiContentNotFoundError("Not found")
+            )
+            mock_get.return_value = mock_client
+
+            # Act & Assert
+            with pytest.raises(ContentNotFoundError):
+                await connected_connector.fetch_content("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_fetch_content_with_content_type(self, connected_connector):
+        """Test fetching content with specific content type."""
+        # Arrange
+        expected_item = ContentItem(
+            content_id="blog123",
+            content_type="blog",
+            title="Blog Post",
+            body="Blog content"
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.fetch_content = AsyncMock(return_value=expected_item)
+            mock_get.return_value = mock_client
+
+            # Act
+            result = await connected_connector.fetch_content(
+                "blog123",
+                content_type="blog"
+            )
+
+            # Assert
+            assert result.content_type == "blog"
+
+
+class TestStrapiConnectorPushContent:
+    """Tests for pushing content."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_push_content_success(self, connected_connector):
+        """Test pushing new content."""
+        # Arrange
+        content = ContentItem(
+            content_type="article",
+            title="New Article",
+            body="Article body"
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.push_content = AsyncMock(return_value="new123")
+            mock_get.return_value = mock_client
+
+            # Act
+            content_id = await connected_connector.push_content(content)
+
+            # Assert
+            assert content_id == "new123"
+
+    @pytest.mark.asyncio
+    async def test_push_content_with_metadata(self, connected_connector):
+        """Test pushing content with metadata."""
+        # Arrange
+        content = ContentItem(
+            content_type="article",
+            title="Article with Metadata",
+            body="Body content",
+            metadata={"author": "Test Author", "category": "tech"}
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.push_content = AsyncMock(return_value="meta123")
+            mock_get.return_value = mock_client
+
+            # Act
+            content_id = await connected_connector.push_content(content)
+
+            # Assert
+            assert content_id == "meta123"
+            mock_client.push_content.assert_called_once()
+
+
+class TestStrapiConnectorUpdateContent:
+    """Tests for updating content."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_update_content_success(self, connected_connector):
+        """Test updating existing content."""
+        # Arrange
+        content = ContentItem(
+            content_type="article",
+            title="Updated Title",
+            body="Updated body"
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.update_content = AsyncMock(return_value=True)
+            mock_get.return_value = mock_client
+
+            # Act
+            result = await connected_connector.update_content("existing123", content)
+
+            # Assert
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_content(self, connected_connector):
+        """Test updating nonexistent content returns False."""
+        # Arrange
+        content = ContentItem(
+            content_type="article",
+            title="Update",
+            body="Body"
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.update_content = AsyncMock(return_value=False)
+            mock_get.return_value = mock_client
+
+            # Act
+            result = await connected_connector.update_content("nonexistent", content)
+
+            # Assert
+            assert result is False
+
+
+class TestStrapiConnectorListContent:
+    """Tests for listing content."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_list_content(self, connected_connector):
+        """Test listing content."""
+        # Arrange
+        expected_items = [
+            ContentItem(content_id="1", content_type="article", title="Article 1", body="Body 1"),
+            ContentItem(content_id="2", content_type="article", title="Article 2", body="Body 2")
+        ]
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.list_content = AsyncMock(return_value=expected_items)
+            mock_get.return_value = mock_client
+
+            # Act
+            items = await connected_connector.list_content()
+
+            # Assert
+            assert len(items) == 2
+            assert items[0].title == "Article 1"
+
+    @pytest.mark.asyncio
+    async def test_list_content_with_type_filter(self, connected_connector):
+        """Test listing content filtered by type."""
+        # Arrange
+        expected_items = [
+            ContentItem(content_id="1", content_type="blog", title="Blog 1", body="Body 1")
+        ]
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.list_content = AsyncMock(return_value=expected_items)
+            mock_get.return_value = mock_client
+
+            # Act
+            items = await connected_connector.list_content(content_type="blog")
+
+            # Assert
+            assert len(items) == 1
+            assert items[0].content_type == "blog"
+
+    @pytest.mark.asyncio
+    async def test_list_content_with_pagination(self, connected_connector):
+        """Test listing content with pagination."""
+        # Arrange
+        expected_items = [
+            ContentItem(content_id="3", content_type="article", title="Article 3", body="Body 3")
+        ]
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.list_content = AsyncMock(return_value=expected_items)
+            mock_get.return_value = mock_client
+
+            # Act
+            items = await connected_connector.list_content(limit=10, offset=20)
+
+            # Assert
+            mock_client.list_content.assert_called_once()
+            call_kwargs = mock_client.list_content.call_args[1]
+            assert call_kwargs.get('limit') == 10
+            assert call_kwargs.get('offset') == 20
+
+
+class TestStrapiConnectorSchema:
+    """Tests for schema operations."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_get_schema(self, connected_connector):
+        """Test getting content type schema."""
+        # Arrange
+        expected_schema = ContentSchema(
+            content_type="article",
+            fields=[
+                ContentField(name="title", field_type=FieldType.STRING, required=True),
+                ContentField(name="content", field_type=FieldType.RICHTEXT, required=True),
+                ContentField(name="tags", field_type=FieldType.ARRAY, required=False)
+            ]
+        )
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.get_schema = AsyncMock(return_value=expected_schema)
+            mock_get.return_value = mock_client
+
+            # Act
+            schema = await connected_connector.get_schema("article")
+
+            # Assert
+            assert schema.content_type == "article"
+            assert len(schema.fields) == 3
+
+
+class TestStrapiConnectorOptionalOperations:
+    """Tests for optional operations (delete, search)."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_delete_content(self, connected_connector):
+        """Test deleting content."""
+        # Note: delete is optional in BaseContentConnector
+        # StrapiConnector may or may not implement it
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            # If delete is implemented
+            if hasattr(mock_client, 'delete_content'):
+                mock_client.delete_content = AsyncMock(return_value=True)
+                mock_get.return_value = mock_client
+
+                result = await connected_connector.delete_content("to-delete")
+                assert result is True
+
+    @pytest.mark.asyncio
+    async def test_search_content(self, connected_connector):
+        """Test searching content."""
+        # Search may not be implemented
+        try:
+            await connected_connector.search_content("test query")
+        except NotImplementedError:
+            # Expected if not implemented
+            pass
+
+
+class TestStrapiConnectorRegistration:
+    """Tests for connector registration."""
+
+    def test_connector_registered_globally(self):
+        """Test that StrapiConnector is registered in global registry."""
+        # Act - import triggers registration
+        from pseudoscribe.infrastructure.strapi_connector import StrapiConnector
+
+        # Assert
+        registry = get_connector_registry()
+        assert registry.is_registered("strapi")
+
+    def test_create_connector_from_registry(self):
+        """Test creating connector from registry."""
+        # Arrange
+        from pseudoscribe.infrastructure.strapi_connector import StrapiConnector
+
+        registry = get_connector_registry()
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test",
+            api_url="https://strapi.example.com",
+            api_token="token"
+        ))
+
+        # Act
+        connector = registry.create(
+            "strapi",
+            tenant_id="tenant-123",
+            credential_id=cred_id,
+            config_service=config_service
+        )
+
+        # Assert
+        assert isinstance(connector, StrapiConnector)
+        assert connector.tenant_id == "tenant-123"
+
+
+class TestStrapiConnectorTenantIsolation:
+    """Tests for multi-tenant isolation."""
+
+    def test_connectors_isolated_by_tenant(self):
+        """Test that connectors are isolated per tenant."""
+        # Arrange
+        config_service = TenantConfigService()
+
+        cred_id_a = config_service.store_credentials("tenant-A", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="strapi-a",
+            api_url="https://a.strapi.example.com",
+            api_token="token_a"
+        ))
+
+        cred_id_b = config_service.store_credentials("tenant-B", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="strapi-b",
+            api_url="https://b.strapi.example.com",
+            api_token="token_b"
+        ))
+
+        # Act
+        connector_a = StrapiConnector("tenant-A", cred_id_a, config_service)
+        connector_b = StrapiConnector("tenant-B", cred_id_b, config_service)
+
+        # Assert
+        assert connector_a.tenant_id != connector_b.tenant_id
+        assert connector_a.get_credentials().api_url != connector_b.get_credentials().api_url
+
+    @pytest.mark.asyncio
+    async def test_operations_use_tenant_credentials(self):
+        """Test that operations use correct tenant credentials."""
+        # Arrange
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="tenant-strapi",
+            api_url="https://tenant.strapi.example.com",
+            api_token="tenant_token"
+        ))
+
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.fetch_content = AsyncMock(return_value=ContentItem(
+                content_id="test",
+                content_type="article",
+                title="Test",
+                body="Body"
+            ))
+            mock_get.return_value = mock_client
+
+            # Act
+            await connector.fetch_content("test")
+
+            # Assert - verify tenant_id was passed
+            mock_client.fetch_content.assert_called_once()
+            call_kwargs = mock_client.fetch_content.call_args[1]
+            assert call_kwargs.get('tenant_id') == "tenant-123"
+
+
+class TestStrapiConnectorDefaultContentType:
+    """Tests for default content type handling."""
+
+    @pytest.fixture
+    def connected_connector(self):
+        """Create a connected connector."""
+        config_service = TenantConfigService()
+        cred_id = config_service.store_credentials("tenant-123", ConnectorCredentials(
+            credential_type=CredentialType.STRAPI,
+            name="test-strapi",
+            api_url="https://strapi.example.com",
+            api_token="test_token"
+        ))
+        connector = StrapiConnector("tenant-123", cred_id, config_service)
+        connector._connected = True
+        connector._default_content_type = "article"
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_fetch_uses_default_content_type(self, connected_connector):
+        """Test that fetch uses default content type when not specified."""
+        # Arrange
+        with patch.object(StrapiMCPClient, 'get_instance') as mock_get:
+            mock_client = MagicMock()
+            mock_client.fetch_content = AsyncMock(return_value=ContentItem(
+                content_id="test",
+                content_type="article",
+                title="Test",
+                body="Body"
+            ))
+            mock_get.return_value = mock_client
+
+            # Act
+            await connected_connector.fetch_content("test")
+
+            # Assert
+            call_kwargs = mock_client.fetch_content.call_args[1]
+            assert call_kwargs.get('content_type') == "article"
+
+    def test_set_default_content_type(self, connected_connector):
+        """Test setting default content type."""
+        # Act
+        connected_connector.set_default_content_type("blog")
+
+        # Assert
+        assert connected_connector._default_content_type == "blog"


### PR DESCRIPTION
## Summary
- Implement `StrapiConnector` extending `BaseContentConnector` for unified content management
- Integrate with `StrapiMCPClient` for all MCP operations
- Support all CRUD operations (fetch, push, update, list)
- Add schema introspection for content type discovery
- Include configurable default content type
- Register connector with global `ConnectorRegistry` for discovery
- Support multi-tenant isolation with per-tenant credentials

## Architecture
```
StrapiConnector (extends BaseContentConnector)
    └── StrapiMCPClient (singleton)
         └── MCP Server (Strapi GraphQL)
```

## Test Plan
- [x] 27 unit tests covering all functionality
- [x] Inheritance and connector type tests
- [x] Connection management tests
- [x] CRUD operation tests with mocked MCP client
- [x] Schema operations tests
- [x] Connector registry tests
- [x] Multi-tenant isolation tests
- [x] Default content type tests

Closes #118